### PR TITLE
fix: change permissions mask for eggdrop userfile

### DIFF
--- a/templates/eggdrop.conf.j2
+++ b/templates/eggdrop.conf.j2
@@ -58,7 +58,7 @@ set help-path "help/"
 set text-path "text/"
 set motd "text/motd"
 set telnet-banner "text/banner"
-set userfile-perm 0600
+set userfile-perm 0664
 
 ## Botnet/DCC/Telnet
 listen {{ dcc_port }} all


### PR DESCRIPTION
The default of 0600 for file permissions for user, chan, and notes files results in files that cannot be read by the host users, rendering backups inoperable.  This changes that to 0664 so we can back things up properly.