### PR TITLE
Add offsite backup support to the backups pipeline

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,8 +109,9 @@ ansible-playbook deploy-pompone.yml --ask-become-pass --check
 **Variable precedence (lowest to highest):**
 
 1. `ansible/group_vars/all.yml` - Common to all bots
-2. `ansible/host_vars/localhost/botname.yml` - Bot-specific
-3. Command line `-e` flags - Overrides
+2. `ansible/group_vars/backup_ssh_keys.yml` - SSH Public Key inventory for offsite backups
+3. `ansible/host_vars/localhost/botname.yml` - Bot-specific
+4. Command line `-e` flags - Overrides
 
 **Use group_vars for:**
 
@@ -136,6 +137,7 @@ ansible-playbook deploy-pompone.yml --ask-become-pass --check
   
   vars_files:
     - ansible/group_vars/all.yml
+    - ansible/group_vars/backup_ssh_keys.yml
     - ansible/host_vars/localhost/botname.yml
   
   tasks:
@@ -197,8 +199,9 @@ ansible-playbook deploy-pompone.yml --check
 ansible-playbook deploy-pompone.yml --ask-become-pass
 
 # Verify deployment
-docker-compose -f bots/Pompone/docker-compose.yml ps
-docker-compose -f bots/Pompone/docker-compose.yml logs
+cd bots/Pompone
+docker compose ps
+docker compose logs
 ```
 
 ### Git Workflow

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,406 @@
+# Deployment Guide for Bot Administrators
+
+This guide walks through the complete process of deploying a bot from scratch, including SSH key setup for off-site backups.
+
+## Overview
+
+Each bot in the efnetmoto-fleet operates independently on its own host, managed by a bot administrator. The bots form a resilient network where:
+- **Pompone** logs all channel activity and hosts PISG statistics
+- **Decisis** hosts the IRC seen database
+- **XeroKewl** hosts the quote database
+- All bots share userfiles via the botnet
+- All bots back up to all other bots for redundancy
+
+## Prerequisites
+
+- Linux host (Debian and Redhat currently supported)
+- sudo access
+- Git installed
+- (Optional) Existing bot backup for migration
+
+## Step 1: Clone Repository
+
+```bash
+git clone https://github.com/efnetmoto/efnetmoto-fleet.git
+cd efnetmoto-fleet
+```
+
+## Step 2: Run Bootstrap Script
+
+The setup script installs Ansible and required dependencies:
+
+```bash
+chmod +x setup.sh
+./setup.sh
+```
+
+## Step 3: Configure Bot Variables
+
+View your bot's variable file (`ansible/host_vars/localhost/<botname>.yml`):
+
+```yaml
+# Bot Identity
+bot_nick: "<nick>"
+bot_username: "<username>"
+bot_realname: "<realname>"
+bot_admin: "<Your Name> <email@example.com>"
+bot_owner: "<YourIRCHandle>"
+
+# Ports
+dcc_port: 2020
+stats_port: 8080  # Only for Pompone
+```
+
+If you wish to change any of these for your local installation, use the overrides file:
+
+```bash
+cp ansible/host_vars/localhost/override.yml.example ansible/host_vars/localhost/override.yml
+vi ansible/host_vars/localhost/override.yml
+```
+
+## Step 4: Migrate Existing Bot Data (Optional)
+
+If migrating an existing bot, obtain a recent backup from another bot admin and restore from backup:
+
+```bash
+# Copy backup to repository
+mv ~/<botname>-backup-YYYY-MM-DD.tar.gz efnetmoto-fleet/backups/
+
+# Restore the backup and redeploy
+ansible-playbook restore-<botname>.yml --ask-become-pass
+ansible-playbook deploy-<botname>.yml --ask-become-pass
+
+# Restart services to pick up restored data
+cd bots/<botname>
+docker compose restart
+```
+
+## Step 5: Deploy Your Bot
+
+Run the deployment playbook:
+
+```bash
+ansible-playbook deploy-<botname>.yml --ask-become-pass
+```
+
+The playbook will:
+- Install Docker (if needed)
+- Generate SSH backup keypair automatically
+- Update `ansible/group_vars/backup_ssh_keys.yml` with connection details
+- Generate bot configuration from templates
+- Set up SSH authorized_keys for other bots (using keys from repository)
+- Build and start containers
+- Install backup cron jobs
+
+**Important:** The deployment will display a message if SSH keys were generated or updated. You must commit these changes and submit a PR (see Step 8 below).
+
+## Step 6: Verify Deployment
+
+> **Note:** Run Docker Compose commands from the bot's directory to ensure `docker-compose.override.yml` files are automatically loaded for local customizations.
+
+Check that services are running:
+
+```bash
+cd bots/<botname>
+docker compose ps
+```
+
+View logs:
+
+```bash
+cd bots/<botname>
+docker compose logs -f
+```
+
+Verify the bot joined IRC and check for any errors.
+
+## Step 7: Test Backup System
+
+Run a manual backup:
+
+```bash
+ansible-playbook backup-<botname>.yml
+```
+
+Verify the backup was created:
+
+```bash
+ls -lh backups/
+```
+
+The backup will attempt to copy to other bots. If their deployment hasn't been updated with your keys yet, you'll see failures. This is expected - once your PR is merged and they redeploy, backups will succeed.
+
+## Step 8: Commit Your Changes
+
+Create a pull request with your changes:
+
+```bash
+git checkout -b add-<botname>-deployment
+git add ansible/group_vars/backup_ssh_keys.yml
+git add ansible/host_vars/localhost/<botname>.yml
+git commit -m "Add <botname> deployment configuration
+
+- Add bot configuration in host_vars
+- Auto-generated SSH backup keys and connection details"
+git push origin add-<botname>-deployment
+```
+
+**Important:** Once your PR is merged, other bot administrators must pull the latest changes and redeploy to authorize your bot to push backups to them:
+
+```bash
+git pull origin main
+ansible-playbook deploy-<theirbotname>.yml --ask-become-pass
+```
+
+## Ongoing Maintenance
+
+### Backups
+
+#### Automated Backups
+
+Backups run automatically via cron daily (configured during deployment). Check logs:
+
+```bash
+cat /var/log/backup-<botname>.log
+```
+
+#### Manual Backup
+
+Run the backup playbook for any bot:
+
+```bash
+ansible-playbook backup-<botname>.yml
+```
+
+This creates a timestamped backup file:
+
+```text
+backups/<botname>-backup-2023-12-08.tar.gz
+```
+
+#### Backup Retention
+
+Backups older than 30 days (configurable) are automatically deleted when a new backup is created.
+
+To change retention period, edit `backup_retention_days` in your bot's variables file.
+
+#### Restoring from Backup
+
+Backups are restored using a structured restore pipeline that validates the archive and restored contents before cleanup. This helps prevent accidental or partial restores.
+
+**Basic Restore Command:**
+
+```bash
+ansible-playbook -K restore-<botname>.yml --extra-vars "archive_file=backups/<botname>-backup-2023-12-08.tar.gz"
+```
+
+> 📝 **Note:** `-K` (become root) needed to work around file permissions on bot-owned files
+
+**Archive Validation:**
+
+The restore pipeline validates that:
+- Archive filename matches expected format: `<botname>-backup-YYYY-MM-DD.tar.gz`
+- Bot name in filename matches the target bot
+- Archive MIME type indicates gzip compression
+- Required directories (`data/`, `logs/`) were restored
+- Optional artifacts are restored only if they existed in the backup
+
+If validation fails, the restore process stops immediately and the staging directory is preserved for inspection.
+
+**Testing Restores:**
+
+Test your restore procedure periodically to ensure backups are valid!
+
+### Updating Configuration
+
+1. Edit variables in `ansible/host_vars/localhost/<botname>.yml` or `ansible/host_vars/localhost/overrides.yml`
+2. Redeploy: `ansible-playbook deploy-<botname>.yml --ask-become-pass`
+
+### Rotating SSH Keys
+
+If you need to rotate your backup SSH key:
+
+1. Delete old key: `rm ~/.ssh/efnetmoto_backup*`
+2. Redeploy: `ansible-playbook deploy-<botname>.yml --ask-become-pass`
+3. Deployment will auto-generate new keys and update `ansible/group_vars/backup_ssh_keys.yml`
+4. Commit changes and create PR with new keys
+5. Wait for other admins to pull and redeploy to authorize your new key
+
+## Disaster Recovery
+
+This section covers recovering from a complete bot host failure.
+
+### Scenario: Bot Host Failure
+
+If a bot's host becomes unavailable or needs to be rebuilt:
+
+**Step 1: Obtain a Backup**
+
+Contact another bot administrator via IRC to obtain a recent backup file.
+
+**Step 2: Set Up New Host**
+
+Follow the standard deployment procedure (Steps 1-8 in this guide):
+- Clone repository
+- Run bootstrap script
+- Configure bot variables
+- Deploy the bot
+
+The deployment will automatically generate NEW SSH backup keys (old private key is lost) and update `ansible/group_vars/backup_ssh_keys.yml` with your new connection details (user, host, path, ssh_public_key).
+
+**Step 3: Restore from Backup**
+
+```bash
+# Copy backup to repository
+mv ~/<botname>-backup-YYYY-MM-DD.tar.gz efnetmoto-fleet/backups/
+
+# Restore the backup and redeploy
+ansible-playbook restore-<botname>.yml --ask-become-pass
+ansible-playbook deploy-<botname>.yml --ask-become-pass
+
+# Restart services to pick up restored data
+cd bots/<botname>
+docker compose restart
+```
+
+**Step 4: Update SSH Keys in Repository**
+
+The deployment automatically updated `ansible/group_vars/backup_ssh_keys.yml` with your new SSH public key and connection details. Create a PR with this change:
+
+```bash
+git checkout -b update-<botname>-recovery
+git add ansible/group_vars/backup_ssh_keys.yml
+git commit -m "Update <botname> SSH keys and connection details after recovery"
+git push origin update-<botname>-recovery
+```
+
+**Step 5: Coordinate with Other Admins**
+
+Once your PR is merged, notify other bot administrators to pull and redeploy:
+
+```bash
+git pull origin main
+ansible-playbook deploy-<theirbotname>.yml --ask-become-pass
+```
+
+This will authorize your new SSH key and update your connection details for off-site backups. No manual coordination of hostnames or paths is needed - everything is automatically captured during deployment.
+
+**Step 6: Re-establish Botnet Links**
+
+After restore, verify botnet connectivity. The bots should already know about each other from their restored userfiles.
+
+Check botnet status:
+```
+.bots        # Shows linked bots
+.whom *      # Shows users on all bots
+```
+
+If a bot isn't linking automatically, you may need to update its host information:
+
+```
+.+host <botname> <new-hostname-or-ip>
+.chattr <botname> +h             # Ensure hub flag is set
+.link <botname>                  # Manually initiate link
+```
+
+**Step 7: Verify Backup System**
+
+Test that your bot can now back up to other bots:
+
+```bash
+ansible-playbook backup-<botname>.yml
+```
+
+The backup output will show success/failure for each target bot. Once other admins have pulled and redeployed (Step 5), all targets should show SUCCESS.
+
+**Step 8: Post-Recovery Verification**
+
+- [ ] Bot connects to IRC successfully
+- [ ] Bot joins all expected channels
+- [ ] Botnet links are established (`.bots` shows all bots)
+- [ ] Userfile is intact (`.match *` shows users)
+- [ ] Bot responds to commands
+- [ ] Backups complete successfully
+- [ ] Stats generation works (Pompone only)
+
+### Recovery Time Estimate
+
+With backup file in hand and SSH key coordination with other admins:
+- Fresh host setup: 15-30 minutes
+- Restore and verification: 15-30 minutes
+- SSH key coordination: Depends on other admins' availability
+
+### Notes
+
+- **Private keys are lost** in host failure - this is expected and acceptable
+- **Botnet linking** should be automatic from restored userfiles in most cases
+- **SSH coordination** requires other admins to merge PR and redeploy
+- **Backup retrieval** depends on out-of-band communication (IRC) with other admins
+
+## Troubleshooting
+
+### Bot Won't Connect to IRC
+
+Check server configuration:
+
+```bash
+grep -A 5 "set servers" bots/<botname>/data/eggdrop.conf
+```
+
+Verify network connectivity:
+
+```bash
+docker exec <container-name> ping -c 3 irc.example.com
+```
+
+### Backup Fails to Copy to Remote Hosts
+
+Check SSH connectivity:
+
+```bash
+ssh -i ~/.ssh/efnetmoto_backup user@remote-host
+```
+
+Verify authorized_keys on remote host:
+
+```bash
+# On remote host
+cat ~/.ssh/authorized_keys | grep <your-bot-name>
+```
+
+### Permission Errors
+
+Ensure directories have correct ownership:
+
+```bash
+ls -la bots/<botname>/data/
+```
+
+All files should be owned by UID 100 (container user).
+
+## Security Considerations
+
+- **SSH Keys:** Private keys never leave your host. Only public keys are committed.
+- **Backup Files:** Contain sensitive data (user passwords, channel keys). Stored with 0600 permissions.
+- **Docker Compose Overrides:** Can contain sensitive configuration. These files are gitignored.
+- **Ansible Vault:** Not currently used, but available for highly sensitive data if needed.
+
+## Getting Help
+
+- Review bot-specific README files in `bots/<botname>/`
+- Check CONTRIBUTING.md for development guidelines
+- Contact other bot administrators via IRC
+- Review deployment logs for error messages
+
+## Bot-Specific Notes
+
+### Pompone
+- Runs PISG statistics (cron job installed automatically)
+- Annual stats rotation on January 1st
+- Stats available at https://stats.efnetmoto.com/
+
+### Decisis
+- Hosts IRC seen database
+
+### XeroKewl
+- Hosts quote database

--- a/ansible/group_vars/backup_ssh_keys.yml
+++ b/ansible/group_vars/backup_ssh_keys.yml
@@ -1,0 +1,19 @@
+---
+# SSH connection details for off-site backups
+# Automatically populated during deployment
+backup_ssh_public_keys:
+  decisis:
+    host: ''
+    path: ''
+    ssh_public_key: ''
+    user: ''
+  pompone:
+    host: ''
+    path: ''
+    ssh_public_key: ''
+    user: ''
+  xerokewl:
+    host: ''
+    path: ''
+    ssh_public_key: ''
+    user: ''

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,5 +1,9 @@
 ---
 collections:
+  - name: ansible.posix
+    version: ">=2.1.0"
+  - name: community.crypto
+    version: ">=3.1.0"
   - name: community.docker
     version: ">=3.0.0"
   - name: community.general

--- a/ansible/tasks/backup-finalize.yml
+++ b/ansible/tasks/backup-finalize.yml
@@ -16,11 +16,11 @@
 
 - name: Display backup information
   ansible.builtin.debug:
-    msg: |
-      Backup created successfully!
-      Bot: {{ bot_name }}
-      Location: {{ backup_dir }}/{{ backup_filename }}
-      Size: {{ (backup_file.stat.size / 1024 / 1024) | round(2) }} MB
+    msg:
+      - "Backup created successfully!"
+      - "Bot: {{ bot_name }}"
+      - "Location: {{ backup_dir }}/{{ backup_filename }}"
+      - "Size: {{ (backup_file.stat.size / 1024 / 1024) | round(2) }} MB"
 
 - name: Clean up staging directory
   ansible.builtin.file:
@@ -30,7 +30,7 @@
 - name: Find old backups
   ansible.builtin.find:
     paths: "{{ backup_dir }}"
-    patterns: "{{ bot_name | lower }}-backup-*.tar.gz"
+    patterns: "*-backup-*.tar.gz"
     age: "{{ backup_retention_days }}d"
   register: old_backups
 
@@ -45,3 +45,88 @@
   ansible.builtin.debug:
     msg: "Removed {{ old_backups.files | length }} backup(s) older than {{ backup_retention_days }} days"
   when: old_backups.files | length > 0
+
+- name: Off-site backup execution context
+  ansible.builtin.debug:
+    msg:
+      - "Off-site backup process starting."
+      - "This step copies the latest backup to all configured peer hosts."
+
+- name: Determine off-site backup targets
+  ansible.builtin.set_fact:
+    backup_targets: >-
+      {{
+        backup_ssh_public_keys | dict2items
+        | selectattr('key', 'ne', bot_name | lower)
+        | selectattr('value.ssh_public_key', 'defined')
+        | selectattr('value.ssh_public_key', 'ne', '')
+        | selectattr('value.user', 'defined')
+        | selectattr('value.user', 'ne', '')
+        | selectattr('value.host', 'defined')
+        | selectattr('value.host', 'ne', '')
+        | selectattr('value.path', 'defined')
+        | selectattr('value.path', 'ne', '')
+        | list
+      }}
+
+- name: Copy backup to off-site hosts
+  ansible.builtin.command:
+    cmd: >
+      scp -i {{ ansible_env.HOME }}/.ssh/efnetmoto_backup
+      -o StrictHostKeyChecking=accept-new
+      -o ConnectTimeout=30
+      {{ backup_dir }}/{{ backup_filename }}
+      {{ item.value.user }}@{{ item.value.host }}:{{ item.value.path }}/
+  loop: "{{ backup_targets }}"
+  register: offsite_backup_results
+  ignore_errors: true
+  changed_when: false
+  when: backup_targets | length > 0
+
+- name: Classify off-site backup results
+  ansible.builtin.set_fact:
+    offsite_backup_successes: >-
+      {{ offsite_backup_results.results
+         | selectattr('rc', 'eq', 0)
+         | map(attribute='item.key')
+         | list }}
+    offsite_backup_failures: >-
+      {{ offsite_backup_results.results
+         | selectattr('rc', 'ne', 0)
+         | map(attribute='item.key')
+         | list }}
+  when: offsite_backup_results is defined
+
+- name: Display per-host off-site backup successes
+  ansible.builtin.debug:
+    msg:
+      - "{{ item }}: SUCCESS"
+  loop: "{{ offsite_backup_successes | default([]) }}"
+  when: offsite_backup_successes | length > 0
+
+- name: Display per-host off-site backup failures
+  ansible.builtin.debug:
+    msg:
+      - "{{ item }}: FAILED"
+  loop: "{{ offsite_backup_failures | default([]) }}"
+  when: offsite_backup_failures | length > 0
+
+- name: Display off-site backup summary
+  ansible.builtin.debug:
+    msg:
+      - "Off-site backup summary:"
+      - "Targets configured: {{ backup_targets | length }}"
+      - "Successful backups: {{ offsite_backup_successes | length | default(0) }}"
+      - "Failed backups: {{ offsite_backup_failures | length | default(0) }}"
+      - ""
+      - "RESULT:"
+      - >-
+        {% if backup_targets | length == 0 %}
+        SKIPPED — no off-site targets are configured.
+        {% elif offsite_backup_failures | length == 0 %}
+        OK — all off-site backups completed successfully.
+        {% elif offsite_backup_successes | length > 0 %}
+        DEGRADED — some off-site backups failed. Review failures above.
+        {% else %}
+        FAILED — no off-site backups succeeded. Manual intervention required.
+        {% endif %}

--- a/ansible/tasks/deploy-common.yml
+++ b/ansible/tasks/deploy-common.yml
@@ -1,3 +1,6 @@
+---
+# Common deployment tasks for all bots
+
 - name: Install Docker if not already installed
   ansible.builtin.include_role:
     name: geerlingguy.docker
@@ -22,11 +25,11 @@
 
 - name: Warn if userfile is missing
   ansible.builtin.debug:
-    msg: |
-      WARNING: Userfile not found at bots/{{ bot_nick }}/data/{{ bot_nick }}.user
-      This is expected for first deployment. Make sure to migrate your existing
-      userfile (and optionally chan and notes file(s)) before starting the bot.
-      See bots/{{ bot_nick }}/data/README.md for migration instructions.
+    msg:
+      - "WARNING: Userfile not found at bots/{{ bot_nick }}/data/{{ bot_nick }}.user"
+      - "This is expected for first deployment. Make sure to migrate your existing"
+      - "userfile (and optionally chan and notes file(s)) before starting the bot."
+      - "See bots/{{ bot_nick }}/data/README.md for migration instructions."
   when: not userfile_stat.stat.exists
 
 - name: Generate eggdrop.conf from template
@@ -43,3 +46,129 @@
     job: >
       /usr/bin/env ansible-playbook {{ playbook_dir }}/backup-{{ bot_nick | lower }}.yml
       > /dev/null
+
+- name: Generate backup SSH keypair
+  community.crypto.openssh_keypair:
+    path: "{{ ansible_env.HOME }}/.ssh/efnetmoto_backup"
+    type: ed25519
+    comment: "{{ bot_nick | lower }}-backup"
+    state: present
+  register: backup_keypair
+
+- name: Update backup SSH connection details in repository
+  ansible.builtin.set_fact:
+    updated_backup_keys: >-
+      {{
+        backup_ssh_public_keys
+        | combine(
+            {
+              (bot_nick | lower): backup_key_record
+            },
+            recursive=true
+          )
+      }}
+  vars:
+    backup_key_record:
+      user: "{{ ansible_user_id }}"
+      host: "{{ ansible_fqdn }}"
+      path: "{{ ansible_env.PWD }}/backups"
+      ssh_public_key: "{{ backup_keypair.public_key }}"
+  when: backup_keypair.public_key is defined
+
+- name: Write updated backup SSH keys to dedicated file
+  ansible.builtin.copy:
+    content: |
+      ---
+      # SSH connection details for off-site backups
+      # Automatically populated during deployment
+      backup_ssh_public_keys:
+      {{ updated_backup_keys | to_nice_yaml(indent=2) | indent(2, first=True) }}
+    dest: "{{ playbook_dir }}/ansible/group_vars/backup_ssh_keys.yml"
+    mode: '0644'
+  when: backup_keypair.public_key is defined
+
+- name: Build list of other bots' backup SSH keys
+  ansible.builtin.set_fact:
+    other_bot_keys: >-
+      {{
+        backup_ssh_public_keys
+        | dict2items
+        | selectattr('key', 'ne', bot_nick | lower)
+        | selectattr('value.ssh_public_key', 'defined')
+        | selectattr('value.ssh_public_key', 'ne', '')
+        | list
+      }}
+
+- name: Add other bots' public keys to authorized_keys
+  ansible.posix.authorized_key:
+    user: "{{ ansible_user_id }}"
+    key: "{{ item.value.ssh_public_key }}"
+    state: present
+    key_options: >-
+      restrict,command="case \"$SSH_ORIGINAL_COMMAND\" in
+      scp\ -t\ */efnetmoto-fleet/backups/*)
+      exec $SSH_ORIGINAL_COMMAND;;
+      *) exit 1;;
+      esac"
+    comment: "efnetmoto backup from {{ item.key }}"
+  loop: "{{ other_bot_keys }}"
+  when: other_bot_keys | length > 0
+
+- name: Check if backup SSH key is valid
+  ansible.builtin.set_fact:
+    bot_config_in_repo: "{{ backup_ssh_public_keys[bot_nick | lower] | default({}) }}"
+    bot_key_in_repo: "{{ bot_config_in_repo.ssh_public_key | default('') }}"
+    backup_pubkey: "{{ backup_keypair.public_key }}"
+
+- name: Validate backup SSH key configuration
+  ansible.builtin.set_fact:
+    backup_ssh_key_valid: "{{ bot_key_in_repo != '' and backup_pubkey in bot_key_in_repo }}"
+
+- name: Backup SSH key requires user action
+  when: backup_keypair.changed or not backup_ssh_key_valid
+  block:
+
+    - name: Display newly generated backup SSH key
+      ansible.builtin.debug:
+        msg:
+          - "A new SSH backup key has been generated for this bot."
+          - "Connection details have been automatically added to:"
+          - "  ansible/group_vars/backup_ssh_keys.yml"
+          - "  backup_ssh_public_keys.{{ bot_nick | lower }}"
+          - ""
+          - "You must commit these changes and submit a PR so other hosts"
+          - "can authorize this bot to push backups to them."
+      when: backup_keypair.changed  # noqa: no-handler
+
+    - name: Warn when repository key does not match
+      ansible.builtin.debug:
+        msg:
+          - "WARNING: Backup SSH key configuration is incomplete."
+          - "The public key configured on this host does not match the repository."
+          - ""
+          - "Host key:"
+          - "{{ backup_pubkey }}"
+          - ""
+          - "Repository key:"
+          - "{{ bot_key_in_repo | default('NOT SET') }}"
+          - ""
+          - "Update ansible/group_vars/backup_ssh_keys.yml and create a PR to resolve this."
+      when: not backup_ssh_key_valid
+
+    - name: Backup SSH configuration requires action
+      ansible.builtin.debug:
+        msg:
+          - "RESULT: ACTION REQUIRED"
+          - "Backup SSH is NOT fully configured."
+          - "See messages above for required changes."
+
+- name: Backup SSH configuration verified
+  ansible.builtin.debug:
+    msg:
+      - "RESULT: OK"
+      - "Backup SSH configuration complete."
+      - "This host is authorized to push backups."
+      - "{{ other_bot_keys | length }} other bot(s) may push backups to this host."
+  when:
+    - backup_ssh_key_valid
+    - not backup_keypair.changed

--- a/backup-pompone.yml
+++ b/backup-pompone.yml
@@ -5,6 +5,7 @@
 
   vars_files:
     - ansible/group_vars/all.yml
+    - ansible/group_vars/backup_ssh_keys.yml
     - ansible/host_vars/localhost/pompone.yml
 
   vars:

--- a/deploy-pompone.yml
+++ b/deploy-pompone.yml
@@ -5,6 +5,7 @@
 
   vars_files:
     - ansible/group_vars/all.yml
+    - ansible/group_vars/backup_ssh_keys.yml
     - ansible/host_vars/localhost/pompone.yml
 
   tasks:
@@ -82,24 +83,63 @@
         month: "1"
       when: pisg_enabled | default(false)
 
+    - name: Extract IRC ports for firewall configuration
+      ansible.builtin.set_fact:
+        irc_ports: "{{ irc_servers | map(attribute='port') | map('regex_replace', '^\\+', '') | unique | sort | list }}"
+
     - name: Deploy Pompone with docker-compose
       community.docker.docker_compose_v2:
         project_src: bots/Pompone
         state: present
 
+    - name: Build Pompone next steps message
+      ansible.builtin.set_fact:
+        pompone_next_steps: >-
+          {{
+            [
+              "=" * 72,
+              "Pompone deployment complete!",
+              "=" * 72,
+              "",
+              "FIREWALL CONFIGURATION REQUIRED:",
+              "-" * 33,
+              "You must configure your firewall to allow the following:",
+              "",
+              "INBOUND:",
+              "  - Port " ~ environment_variables.dcc_port ~
+              " (DCC - botnet communication)"
+            ]
+            + (
+              [
+                "  - Port " ~ environment_variables.stats_port ~
+                " (HTTP - PISG statistics)"
+              ]
+              if pisg_enabled | default(false) else []
+            )
+            + [
+              "",
+              "OUTBOUND:",
+              "  - Ports " ~ (irc_ports | join(', ')) ~ " (IRC servers)",
+              "  - Port 22 (SSH - for off-site backups)",
+              "",
+              "MANAGEMENT COMMANDS:",
+              "-" * 20,
+              "View logs:",
+              "  cd bots/Pompone && docker compose logs -f",
+              "",
+              "Check status:",
+              "  cd bots/Pompone && docker compose ps",
+              "",
+              "NEXT STEPS:",
+              "-" * 11,
+              "1. Configure firewall (see above)",
+              "2. Link to botnet (see README.md for Post-deploy requirements)",
+              "3. Test backup: ansible-playbook backup-pompone.yml",
+              "",
+              "=" * 72
+            ]
+          }}
+
     - name: Display next steps
       ansible.builtin.debug:
-        msg: |
-          Pompone deployment complete!
-
-          To view logs:
-            docker compose -f bots/Pompone/docker-compose.yml logs -f
-
-          To check status:
-            docker compose -f bots/Pompone/docker-compose.yml ps
-
-          To connect via telnet (if configured):
-            telnet localhost 2020
-
-          You must open `{{ dcc_port }}` on your firewall so the bots can
-          connect to each other.
+        msg: "{{ pompone_next_steps }}"

--- a/rotate-pompone-pisg.yml
+++ b/rotate-pompone-pisg.yml
@@ -86,14 +86,14 @@
 
     - name: Display rotation summary
       ansible.builtin.debug:
-        msg: |
-          PISG rotation completed for {{ archive_year }}!
-
-          Actions taken:
-          - Archived {{ year_logs.matched }} log file(s) to archives/logs-{{ archive_year }}.tar.gz
-          - Moved {{ current_html.matched }} HTML file(s) to html/{{ archive_year }}/
-          - Updated footer.txt with links to {{ sorted_years | length }} year(s) of archives
-
-          Next steps:
-          - PISG will regenerate stats for current year on next run
-          - Previous years accessible at: /{{ archive_year }}/
+        msg:
+          - "PISG rotation completed for {{ archive_year }}!"
+          - ""
+          - "Actions taken:"
+          - "- Archived {{ year_logs.matched }} log file(s) to archives/logs-{{ archive_year }}.tar.gz"
+          - "- Moved {{ current_html.matched }} HTML file(s) to html/{{ archive_year }}/"
+          - "- Updated footer.txt with links to {{ sorted_years | length }} year(s) of archives"
+          - ""
+          - "Next steps:"
+          - "- PISG will regenerate stats for current year on next run"
+          - "- Previous years accessible at: /{{ archive_year }}/"

--- a/shared/tcl-scripts/README.md
+++ b/shared/tcl-scripts/README.md
@@ -23,5 +23,6 @@ is done via the bot-specific ansible variables in `host_vars/`.
 1. Restart the bot(s)
 
    ```bash
-   docker compose -f bots/<botname>/docker-compose.yml restart
+   cd bots/<botname>
+   docker compose restart
    ```


### PR DESCRIPTION
Implements a secure offsite backup system where each bot automatically
backs up to peer hosts after creating its own backup. The system handles
SSH key generation, authorization, and secure file transfer with minimal
manual intervention.

Key Generation and Distribution:
- Deployment automatically generates an ssh keypair for backups
- Connection details (user, host, path, ssh_key) are auto-populated from
ansible facts (ansible_user_id, ansible_fqdn, ansible_env.PWD)
- Details are written to ansible/group_vars/all.yml for distribution
- Bot admins must submit a PR after deployment to share their connection
details with peer hosts (deployment output clearly indicates this)

Security Hardening:
- SSH keys added to authorized_keys with 'restrict' option (blocks shells,
forwarding, PTY allocation, agent forwarding, user rc)
- Command restriction allows ONLY 'scp -t */efnetmoto-fleet/backups/*'
- Other bot admins can only push backups to the designated directory and
nothing else - no shell access, no reading files, no other operations

Offsite Backup Process:
- After local backup completes, backup-finalize.yml identifies all peer
hosts with complete connection details
- Pushes latest backup via SCP to each configured peer host
- Reports per-host success/failure and overall status (OK, DEGRADED, FAILED)

Also includes various documentation and output changes to increase style continuity,
accuracy, and better organize by audience.