### PR TITLE
Refactor backup SSH restrictions to use legacy SCP validation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 backups/*
 !backups/README.md
 
+# Shared bin files
+shared/bin/*
+!shared/bin/README.md
+
 # Bot runtime data
 bots/*/data/*
 !bots/*/data/README.md

--- a/ansible/tasks/backup-finalize.yml
+++ b/ansible/tasks/backup-finalize.yml
@@ -72,7 +72,7 @@
 - name: Copy backup to off-site hosts
   ansible.builtin.command:
     cmd: >
-      scp -i {{ ansible_env.HOME }}/.ssh/efnetmoto_backup
+      scp -O -i {{ ansible_env.HOME }}/.ssh/efnetmoto_backup
       -o StrictHostKeyChecking=accept-new
       -o ConnectTimeout=30
       {{ backup_dir }}/{{ backup_filename }}

--- a/ansible/tasks/deploy-prepare.yml
+++ b/ansible/tasks/deploy-prepare.yml
@@ -101,6 +101,14 @@
     mode: '0644'
   when: backup_keypair.public_key is defined
 
+- name: Create restricted SFTP wrapper script for backup key
+  ansible.builtin.template:
+    src: templates/backups-sftp-restriction.sh.j2
+    dest: shared/bin/backups-sftp-restriction.sh
+    mode: "0755"
+  vars:
+    local_backups_dir: "{{ playbook_dir }}/backups"
+
 - name: Build list of other bots' backup SSH keys
   ansible.builtin.set_fact:
     other_bot_keys: >-
@@ -119,11 +127,7 @@
     key: "{{ item.value.ssh_public_key }}"
     state: present
     key_options: >-
-      restrict,command="case \"$SSH_ORIGINAL_COMMAND\" in
-      scp\ -t\ */efnetmoto-fleet/backups/*)
-      exec $SSH_ORIGINAL_COMMAND;;
-      *) exit 1;;
-      esac"
+      restrict,command="{{ playbook_dir }}/shared/bin/backups-sftp-restriction.sh"
     comment: "efnetmoto backup from {{ item.key }}"
   loop: "{{ other_bot_keys }}"
   when: other_bot_keys | length > 0

--- a/shared/bin/README.md
+++ b/shared/bin/README.md
@@ -1,0 +1,8 @@
+# Shared Utilities and Scripts
+
+This directory contains host-level utility scripts and executables that support bot operations and infrastructure.
+
+These are typically system-level tools that run on the host rather than inside bot containers. Examples include SSH
+forced command scripts for restricting SFTP access, backup utilities, and other infrastructure tooling.
+
+Files in this directory are gitignored, as they are generated during deployment from templates or other setup processes.

--- a/templates/backups-sftp-restriction.sh.j2
+++ b/templates/backups-sftp-restriction.sh.j2
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+# Restrict backup SSH key to legacy SCP writes to backups directory only
+ALLOWED_DIR="{{ local_backups_dir }}"
+
+case "$SSH_ORIGINAL_COMMAND" in
+  scp\ -t\ "$ALLOWED_DIR"/*)
+    # Allow SCP receive (write) to backups directory
+    exec $SSH_ORIGINAL_COMMAND
+    ;;
+  *)
+    echo "Access denied" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
Replaces inline case statement in authorized_keys with a cleaner wrapper script that validates legacy SCP commands to the backups directory. Forces scp to use legacy protocol with -O flag for proper path validation without requiring system-level chroot. Creates shared/bin directory for host-level utility scripts that support bot infrastructure.

Resolves #21 