### PR TITLE
Refactor pisg stats rotation to use dynamic archive links loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,11 +14,13 @@ bots/*/data/*
 bots/*/logs/**/*
 !bots/*/logs/**/README.md
 
-# Pisg cache and output
+# Pisg archives, cache and output
 bots/*/pisg-cache/*
 !bots/*/pisg-cache/README.md
 bots/*/html/*
 !bots/*/html/README.md
+bots/*/archives/*
+!bots/*/archives/README.md
 
 # Pisg generated config (template-generated, not static)
 bots/*/pisg-config/pisg.cfg

--- a/ansible/tasks/generate-pisg-footer.yml
+++ b/ansible/tasks/generate-pisg-footer.yml
@@ -13,32 +13,14 @@
   ansible.builtin.set_fact:
     sorted_years: "{{ year_dirs.files | map(attribute='path') | map('basename') | sort | reverse | list }}"
 
-- name: Generate footer with archive links
+- name: Generate archive links HTML fragment
+  ansible.builtin.template:
+    src: templates/archive-links.html.j2
+    dest: "{{ bot_dir }}/html/archive-links.html"
+    mode: '0644'
+
+- name: Generate pisg footer with JavaScript loader
   ansible.builtin.template:
     src: templates/pisg-footer.txt.j2
     dest: "{{ bot_dir }}/pisg-config/footer.txt"
     mode: '0644'
-
-- name: Read updated footer content
-  ansible.builtin.slurp:
-    src: "{{ bot_dir }}/pisg-config/footer.txt"
-  register: footer_content
-
-- name: Find all index.html files in year directories
-  ansible.builtin.find:
-    paths: "{{ bot_dir }}/html"
-    patterns: 'index\.html'
-    use_regex: true
-    recurse: true
-  register: year_index_files
-
-- name: Replace archive links block in index.html files
-  ansible.builtin.replace:
-    path: "{{ item.path }}"
-    regexp: '(?s)<!-- BEGIN ARCHIVE LINKS -->.*?<!-- END ARCHIVE LINKS -->'
-    replace: |-
-      <!-- BEGIN ARCHIVE LINKS -->
-      {{ footer_content.content | b64decode | trim }}
-      <!-- END ARCHIVE LINKS -->
-  loop: "{{ year_index_files.files }}"
-  when: year_index_files.matched > 0

--- a/rotate-pompone-pisg.yml
+++ b/rotate-pompone-pisg.yml
@@ -66,7 +66,7 @@
         state: absent
       loop: "{{ last_year_cache.files }}"
 
-    - name: Archive last year's logs and generate stats
+    - name: Archive last year's logs and stats
       when:
         - not last_year_html.stat.exists
         - last_year_logs.matched > 0
@@ -78,16 +78,16 @@
             state: directory
             mode: "0775"
 
-        - name: Move current HTML and PNG to year directory
+        - name: Copy current HTML and PNG to year directory
           ansible.builtin.command:
-            cmd: "mv {{ item.path }} {{ bot_dir }}/html/{{ last_year }}/"
+            cmd: "cp {{ item.path }} {{ bot_dir }}/html/{{ last_year }}/"
           loop: "{{ current_html.files }}"
           when: current_html.matched > 0
           changed_when: true
 
         - name: Archive channel logs for the year
           community.general.archive:
-            path: "{{ year_logs.files | map(attribute='path') | list }}"
+            path: "{{ last_year_logs.files | map(attribute='path') | list }}"
             dest: "{{ bot_dir }}/archives/logs-{{ last_year }}.tar.gz"
             format: gz
             mode: '0664'

--- a/templates/archive-links.html.j2
+++ b/templates/archive-links.html.j2
@@ -1,0 +1,12 @@
+{% if sorted_years is defined and sorted_years | length > 0 %}
+<div align="center">
+  Previous Years' Stats:<br />
+  <a href="/">{{ ansible_date_time.year }}</a> | 
+  {%- for year in sorted_years -%}
+  {%- if loop.first %} {% endif -%}
+  <a href="/{{ year }}/">{{ year }}</a>
+  {%- if not loop.last %} | {% endif -%}
+  {%- endfor %}
+</div>
+{% endif %}
+

--- a/templates/pisg-footer.txt.j2
+++ b/templates/pisg-footer.txt.j2
@@ -1,13 +1,13 @@
-<!-- BEGIN ARCHIVE LINKS -->
-{% if sorted_years is defined and sorted_years | length > 0 %}
-<div align="center">
-  Previous Years' Stats:<br />
-  <a href="/">{{ ansible_date_time.year }}</a> | 
-  {%- for year in sorted_years -%}
-  {%- if loop.first %} {% endif -%}
-  <a href="/{{ year }}/">{{ year }}</a>
-  {%- if not loop.last %} | {% endif -%}
-  {%- endfor %}
-</div>
-{% endif %}
-<!-- END ARCHIVE LINKS -->
+<div id="archive-links"></div>
+<script>
+(function() {
+  var xhr = new XMLHttpRequest();
+  xhr.open("GET", "/archive-links.html", true);
+  xhr.onreadystatechange = function() {
+    if (xhr.readyState === 4 && xhr.status === 200) {
+      document.getElementById("archive-links").innerHTML = xhr.responseText;
+    }
+  };
+  xhr.send();
+})();
+</script>


### PR DESCRIPTION
Replace the previous approach of embedding archive links directly in pisg footer and updating all archived index.html files with a simpler solution: generate a single archive-links.html file that is dynamically loaded via JavaScript. This eliminates the need to modify archived stats pages when the archive list changes, improving maintainability and reducing deployment complexity.