### PR TITLE
fix: use the proper path for backup output

### DIFF
--- a/ansible/tasks/deploy-prepare.yml
+++ b/ansible/tasks/deploy-prepare.yml
@@ -59,7 +59,7 @@
     user: "{{ ansible_user_id }}"
     job: >
       /usr/bin/env ansible-playbook {{ playbook_dir }}/backup-{{ bot_nick | lower }}.yml
-      >> {{ playbook_dir }}/bots/{{ bot_nick | lower }}/logs/backup.{{ ansible_date_time.date }}.log
+      >> {{ playbook_dir }}/bots/{{ bot_nick }}/logs/backup.{{ ansible_date_time.date }}.log
 
 - name: Generate backup SSH keypair
   community.crypto.openssh_keypair:


### PR DESCRIPTION
The backup cronjob was changed to log its output in #35. This introduced a bug where the output is redirected to a path that does not exist. This caused backups to fail.  This fixes the path.

Resolves #40 