### PR TITLE
Add Event Rain to AmbientWeather Output

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.pytestArgs": [
+        "shared/python-scripts"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/shared/python-scripts/tests/weather/test_ambient_provider.py
+++ b/shared/python-scripts/tests/weather/test_ambient_provider.py
@@ -56,6 +56,8 @@ def test_slug_returns_weather_result(provider, slug_loc, ambient_devices_raw_res
     assert result.visibility_km is None
     assert result.rain_today_in == 0.0
     assert result.rain_today_mm == 0.0
+    assert result.event_rain_in == 0.0
+    assert result.event_rain_mm == 0.0
 
 
 @responses_lib.activate

--- a/shared/python-scripts/tests/weather/test_formatter.py
+++ b/shared/python-scripts/tests/weather/test_formatter.py
@@ -135,6 +135,8 @@ def pws_result():
         uv_index=5.0,
         rain_today_in=0.1,
         rain_today_mm=2.5,
+        event_rain_in=0.9,
+        event_rain_mm=22.9,
     )
 
 
@@ -145,7 +147,8 @@ def test_format_pws_metric(pws_result):
         "22.5C/72.5F (Feels like 21.0C/69.8F) (Humidity: 55%) | "
         "Wind: SW at 13.0kph/8.1mph (Gust: 20.1kph/12.5mph) | "
         "UV: 5 | "
-        "Rain today: 2.5mm/0.10in"
+        "Rain today: 2.5mm/0.10in | "
+        "Event rain: 22.9mm/0.90in"
     )
     assert out == expected
 
@@ -186,6 +189,31 @@ def test_format_pws_no_gust(pws_result):
 def test_format_pws_rain_order(pws_result, units, expected):
     out = format_pws(pws_result, units=units)
     assert expected in out
+
+
+@pytest.mark.parametrize(
+    "rain_today_in,rain_today_mm,event_rain_in,event_rain_mm,expect_event_rain",
+    [
+        (1.0, 25.4, 2.0, 50.8, True),
+        (0.0, 0.0, 0.0, 0.0, False),
+    ],
+)
+def test_format_pws_event_rain(
+    pws_result,
+    rain_today_in,
+    rain_today_mm,
+    event_rain_in,
+    event_rain_mm,
+    expect_event_rain,
+):
+    pws_result.rain_today_in = rain_today_in
+    pws_result.rain_today_mm = rain_today_mm
+    pws_result.event_rain_in = event_rain_in
+    pws_result.event_rain_mm = event_rain_mm
+
+    out = format_pws(pws_result, units=Units.METRIC)
+
+    assert ("Event rain" in out) is expect_event_rain
 
 
 def test_format_pws_no_optional_fields():

--- a/shared/python-scripts/weather/formatter.py
+++ b/shared/python-scripts/weather/formatter.py
@@ -2,11 +2,19 @@ from weather.models import ForecastResult, Units, WeatherResult
 
 
 def _dual(
-    metric_val: float, metric_unit: str, imperial_val: float, imperial_unit: str, units: Units
+    metric_val: float,
+    metric_unit: str,
+    imperial_val: float,
+    imperial_unit: str,
+    units: Units,
+    metric_fmt: str = ".1f",
+    imperial_fmt: str = ".1f",
 ) -> str:
     if units == Units.METRIC:
-        return f"{metric_val:.1f}{metric_unit}/{imperial_val:.1f}{imperial_unit}"
-    return f"{imperial_val:.1f}{imperial_unit}/{metric_val:.1f}{metric_unit}"
+        return (
+            f"{metric_val:{metric_fmt}}{metric_unit}/{imperial_val:{imperial_fmt}}{imperial_unit}"
+        )
+    return f"{imperial_val:{imperial_fmt}}{imperial_unit}/{metric_val:{metric_fmt}}{metric_unit}"
 
 
 def format_pws(result: WeatherResult, units: Units = Units.METRIC) -> str:
@@ -31,24 +39,32 @@ def format_pws(result: WeatherResult, units: Units = Units.METRIC) -> str:
         pipe_fields.append(f"UV: {result.uv_index:.0f}")
 
     if result.rain_today_in is not None and result.rain_today_mm is not None:
-        if units == Units.METRIC:
-            pipe_fields.append(
-                f"Rain today: {result.rain_today_mm:.1f}mm/{result.rain_today_in:.2f}in"
-            )
-        else:
-            pipe_fields.append(
-                f"Rain today: {result.rain_today_in:.2f}in/{result.rain_today_mm:.1f}mm"
-            )
+        rain_today = _dual(
+            result.rain_today_mm,
+            "mm",
+            result.rain_today_in,
+            "in",
+            units,
+            ".1f",
+            ".2f",
+        )
+        pipe_fields.append(f"Rain today: {rain_today}")
 
-        if result.rain_today_in > 0:
-            if units == Units.METRIC:
-                pipe_fields.append(
-                    f"Event rain: {result.event_rain_mm:.1f}mm/{result.event_rain_in:.2f}in"
-                )
-            else:
-                pipe_fields.append(
-                    f"Event rain: {result.event_rain_in:.2f}in/{result.event_rain_mm:.1f}mm"
-                )
+        if (
+            result.rain_today_in > 0
+            and result.event_rain_in is not None
+            and result.event_rain_mm is not None
+        ):
+            event_rain = _dual(
+                result.event_rain_mm,
+                "mm",
+                result.event_rain_in,
+                "in",
+                units,
+                ".1f",
+                ".2f",
+            )
+            pipe_fields.append(f"Event rain: {event_rain}")
 
     return f"PWS: {result.location_name} :: " + " | ".join(pipe_fields)
 

--- a/shared/python-scripts/weather/formatter.py
+++ b/shared/python-scripts/weather/formatter.py
@@ -40,6 +40,16 @@ def format_pws(result: WeatherResult, units: Units = Units.METRIC) -> str:
                 f"Rain today: {result.rain_today_in:.2f}in/{result.rain_today_mm:.1f}mm"
             )
 
+        if result.rain_today_in > 0:
+            if units == Units.METRIC:
+                pipe_fields.append(
+                    f"Event rain: {result.event_rain_mm:.1f}mm/{result.event_rain_in:.2f}in"
+                )
+            else:
+                pipe_fields.append(
+                    f"Event rain: {result.event_rain_in:.2f}in/{result.event_rain_mm:.1f}mm"
+                )
+
     return f"PWS: {result.location_name} :: " + " | ".join(pipe_fields)
 
 

--- a/shared/python-scripts/weather/models.py
+++ b/shared/python-scripts/weather/models.py
@@ -47,6 +47,8 @@ class WeatherResult:
     metar_raw: str | None = None  # AvWxProvider only
     rain_today_in: float | None = None  # AmbientProvider only
     rain_today_mm: float | None = None  # AmbientProvider only
+    event_rain_in: float | None = None  # AmbientProvider only
+    event_rain_mm: float | None = None  # AmbientProvider only
 
 
 @dataclass

--- a/shared/python-scripts/weather/providers/ambient.py
+++ b/shared/python-scripts/weather/providers/ambient.py
@@ -84,13 +84,21 @@ class AmbientProvider(WeatherProvider):
             raw_uv = last.get("uv")
             uv_index: float | None = float(raw_uv) if raw_uv is not None else None
 
-            raw_rain = last.get("dailyrainin")
-            if raw_rain is not None:
-                rain_today_in: float | None = float(raw_rain)
+            raw_daily_rain = last.get("dailyrainin")
+            if raw_daily_rain is not None:
+                rain_today_in: float | None = float(raw_daily_rain)
                 rain_today_mm: float | None = inches_to_mm(rain_today_in)
             else:
                 rain_today_in = None
                 rain_today_mm = None
+
+            raw_event_rain = last.get("eventrainin")
+            if raw_event_rain is not None:
+                event_rain_in: float | None = float(raw_event_rain)
+                event_rain_mm: float | None = inches_to_mm(event_rain_in)
+            else:
+                event_rain_in = None
+                event_rain_mm = None
 
         except (KeyError, TypeError, ValueError, IndexError) as exc:
             raise ProviderError(f"Could not parse Ambient Weather response: {exc}")
@@ -113,4 +121,6 @@ class AmbientProvider(WeatherProvider):
             uv_index=uv_index,
             rain_today_in=rain_today_in,
             rain_today_mm=rain_today_mm,
+            event_rain_in=event_rain_in,
+            event_rain_mm=event_rain_mm,
         )


### PR DESCRIPTION
If daily rain is non-zero and non-null, then we show the Event rain
(the rain for the current storm) to show total rainfall instead of simply
rain since midnight.