### PR TITLE
Shuffle IRC server list at template time

### DIFF
--- a/ansible/tasks/deploy-prepare.yml
+++ b/ansible/tasks/deploy-prepare.yml
@@ -8,18 +8,6 @@
       become: true
   when: manage_docker | bool
 
-# TODO: Remove this once this change has been run once. The purpose of this
-# play is to migrate all file ownership back to the user that runs the playbooks.
-# It is not needed after this migration.
-- name: Ensure file ownership for entire repo
-  ansible.builtin.file:
-    path: "{{ playbook_dir }}"
-    state: "directory"
-    owner: "{{ ansible_user_uid }}"
-    group: "{{ ansible_user_gid }}"
-    recurse: true
-  become: true
-
 - name: Create runtime directories if they don't exist
   ansible.builtin.file:
     path: "{{ item }}"

--- a/templates/eggdrop.conf.j2
+++ b/templates/eggdrop.conf.j2
@@ -164,7 +164,7 @@ proc evnt:init_server {type} {
 }
 
 set default-port 6667
-{% for server in irc_servers %}
+{% for server in irc_servers | shuffle %}
 {% if server.port is defined %}
 {% if server.password is defined %}
 server add {{ server.host }} {{ server.port }} {{ server.password }}


### PR DESCRIPTION
So all bots don't hammer the same EFNet server in the same order on
deploy; each ansible run now templates a freshly randomized order.
