### PR TITLE
feat: support weather commands via private message

### DIFF
--- a/shared/python-scripts/tests/weather/test_weather_handlers.py
+++ b/shared/python-scripts/tests/weather/test_weather_handlers.py
@@ -148,8 +148,8 @@ def test_wz_user_with_explicit_imperial_overrides_pref():
     ):
         w.handle_wz("AskingNick", "host@example.com", "*", "#moto", "--user foo --imperial")
     mock_fetch.assert_called_once()
-    # units is the 4th positional arg (index 3): nick, handle, metar, units, ...
-    assert mock_fetch.call_args[0][3] == Units.IMPERIAL
+    # units is the 3rd positional arg (index 2): handle, metar, units, ...
+    assert mock_fetch.call_args[0][2] == Units.IMPERIAL
 
 
 def test_wz_user_combined_with_location_rejected(putserv_mock):
@@ -302,3 +302,107 @@ def test_wzhelp_sends_pm_lines(putserv_mock):
     final_msg = putserv_mock.call_args_list[-1][0][0]
     assert "PRIVMSG #moto :" in final_msg
     assert "help sent via PM" in final_msg
+
+
+# PM-bind adapters: handle_wz_msg / handle_wzset_msg / handle_wzhelp_msg
+
+
+def test_wz_msg_replies_to_nick_no_prefix(putserv_mock):
+    """PM invocation: reply target is the nick, no 'nick: ' prefix on errors."""
+    with patch.object(w.prefs, "get_pref", return_value=None):
+        w.handle_wz_msg("SomeNick", "host@example.com", "somehandle", "")
+    putserv_mock.assert_called_once()
+    msg = putserv_mock.call_args[0][0]
+    assert msg.startswith("PRIVMSG SomeNick :")
+    body = msg.split(":", 1)[1]
+    assert not body.startswith("SomeNick:")  # no nick prefix in PM
+    assert "No default set" in msg
+
+
+def test_wz_msg_with_location_unregistered_user_allowed():
+    """Ad-hoc PM .wz <location> reaches the resolver for unregistered users."""
+    with (
+        patch.object(w._router, "route", side_effect=Exception("stop here")),
+        patch.object(w.resolver, "classify", return_value=MagicMock()) as mock_classify,
+    ):
+        w.handle_wz_msg("SomeNick", "host@example.com", "*", "94025")
+    mock_classify.assert_called_once_with("94025")
+
+
+def test_wz_msg_user_flag_rejected(putserv_mock):
+    """--user is channel-only; in PM, return a clear error to the user."""
+    w.handle_wz_msg("AskingNick", "host@example.com", "somehandle", "--user foo")
+    putserv_mock.assert_called_once()
+    msg = putserv_mock.call_args[0][0]
+    assert msg.startswith("PRIVMSG AskingNick :")
+    assert "--user only works in a channel" in msg
+
+
+def test_wz_msg_conflicting_unit_flags_rejected(putserv_mock):
+    """Flag-parse errors in PM go to the nick with no prefix."""
+    w.handle_wz_msg("SomeNick", "host@example.com", "somehandle", "--metric --imperial 94025")
+    putserv_mock.assert_called_once()
+    msg = putserv_mock.call_args[0][0]
+    assert msg.startswith("PRIVMSG SomeNick :")
+    assert "--metric or --imperial, not both" in msg
+
+
+def test_wzset_msg_unregistered_user_blocked(putserv_mock):
+    """PM .wzset for unregistered user is blocked, error goes to PM."""
+    w.handle_wzset_msg("SomeNick", "host@example.com", "*", "94025")
+    putserv_mock.assert_called_once()
+    msg = putserv_mock.call_args[0][0]
+    assert msg.startswith("PRIVMSG SomeNick :")
+    assert "registered bot user" in msg
+
+
+def test_wzset_msg_saves_location(putserv_mock):
+    """PM .wzset <location> saves and confirms via PM, no nick prefix on the confirmation."""
+    mock_provider = MagicMock()
+    with (
+        patch.object(w._router, "route", return_value=mock_provider),
+        patch.object(w.prefs, "get_pref", return_value=None),
+        patch.object(w.prefs, "set_pref") as mock_set,
+    ):
+        w.handle_wzset_msg("SomeNick", "host@example.com", "somehandle", "94025")
+    mock_set.assert_called_once()
+    msg = putserv_mock.call_args[0][0]
+    assert msg.startswith("PRIVMSG SomeNick :")
+    assert "Default set to" in msg
+    assert "94025" in msg
+    # No 'SomeNick: ' prefix on the body
+    body = msg.split(":", 1)[1]
+    assert not body.startswith("SomeNick:")
+
+
+def test_wzhelp_msg_no_channel_echo(putserv_mock):
+    """PM .wzhelp sends help lines only — no channel echo."""
+    w.handle_wzhelp_msg("SomeNick", "host@example.com", "somehandle")
+    assert putserv_mock.call_count == len(w.HELP_LINES)
+    for call in putserv_mock.call_args_list:
+        assert call[0][0].startswith("PRIVMSG SomeNick :")
+    # None of the calls should be the "help sent via PM" channel echo
+    for call in putserv_mock.call_args_list:
+        assert "help sent via PM" not in call[0][0]
+
+
+# Binds: each weather command routes to its expected handler.
+
+
+@pytest.mark.parametrize(
+    "kind,command,handler_name",
+    [
+        ("pub", ".w", "handle_wz"),
+        ("pub", ".wz", "handle_wz"),
+        ("pub", ".wzset", "handle_wzset"),
+        ("pub", ".wzhelp", "handle_wzhelp"),
+        ("msg", ".w", "handle_wz_msg"),
+        ("msg", ".wz", "handle_wz_msg"),
+        ("msg", ".wzset", "handle_wzset_msg"),
+        ("msg", ".wzhelp", "handle_wzhelp_msg"),
+    ],
+)
+def test_bind_registered(kind, command, handler_name):
+    """Each (kind, command) tuple is bound to the named handler — not just any handler."""
+    expected = (kind, "*", command, getattr(w, handler_name))
+    assert expected in [call[0] for call in _bind.call_args_list]

--- a/shared/python-scripts/weather.py
+++ b/shared/python-scripts/weather.py
@@ -107,13 +107,13 @@ def _pref_to_str(pref: UserPref) -> str:
 
 
 def _do_fetch_weather(
-    nick: str,
     handle: str,
     metar: bool,
     units: Units,
     query: str,
     units_explicit: bool,
-    channel: str,
+    reply_target: str,
+    prefix: str,
     target_user: str | None = None,
 ) -> None:
     if target_user:
@@ -124,11 +124,13 @@ def _do_fetch_weather(
         except (TypeError, ValueError):
             registered = False
         if not registered:
-            putserv(f"PRIVMSG {channel} :{nick}: {target_user} is not registered with the bot.")
+            putserv(
+                f"PRIVMSG {reply_target} :{prefix}{target_user} is not registered with the bot."
+            )
             return
         pref = prefs.get_pref(target_user)
         if pref is None or pref.location is None:
-            putserv(f"PRIVMSG {channel} :{nick}: {target_user} has no default location set.")
+            putserv(f"PRIVMSG {reply_target} :{prefix}{target_user} has no default location set.")
             return
         query = pref.location
         metar = pref.metar
@@ -137,17 +139,17 @@ def _do_fetch_weather(
     elif not query:
         if handle == "*":
             putserv(
-                f"PRIVMSG {channel} :{nick}: You must be registered with the bot"
+                f"PRIVMSG {reply_target} :{prefix}You must be registered with the bot"
                 f" to use a saved default. Try .wz <location>."
             )
             return
         pref = prefs.get_pref(handle)
         if pref is None:
-            putserv(f"PRIVMSG {channel} :{nick}: No default set. Use .wzset <location>.")
+            putserv(f"PRIVMSG {reply_target} :{prefix}No default set. Use .wzset <location>.")
             return
         if pref.location is None:
             putserv(
-                f"PRIVMSG {channel} :{nick}: No default location set."
+                f"PRIVMSG {reply_target} :{prefix}No default location set."
                 f" Use .wzset <location> to save one."
             )
             return
@@ -165,19 +167,19 @@ def _do_fetch_weather(
     try:
         loc = resolver.classify(query)
     except ResolverError:
-        putserv(f"PRIVMSG {channel} :{nick}: Unknown location. Try .wzhelp for usage.")
+        putserv(f"PRIVMSG {reply_target} :{prefix}Unknown location. Try .wzhelp for usage.")
         return
 
     try:
         provider = _router.route(loc, metar=metar)
     except ProviderError as e:
-        putserv(f"PRIVMSG {channel} :{nick}: {e}")
+        putserv(f"PRIVMSG {reply_target} :{prefix}{e}")
         return
 
     try:
         result = provider.get_weather(loc)
     except ProviderError as e:
-        putserv(f"PRIVMSG {channel} :{nick}: {e}")
+        putserv(f"PRIVMSG {reply_target} :{prefix}{e}")
         return
 
     if not metar:
@@ -196,45 +198,76 @@ def _do_fetch_weather(
     else:
         output = formatter.format_current(result, forecast=forecast, units=units)
 
-    putserv(f"PRIVMSG {channel} :{output}")
+    putserv(f"PRIVMSG {reply_target} :{output}")
 
 
-def handle_wz(nick: str, host: str, handle: str, channel: str, text: str) -> None:
+def _handle_wz_impl(
+    handle: str,
+    text: str,
+    reply_target: str,
+    prefix: str,
+) -> None:
     try:
         target_user, text = _extract_user_flag(text)
+
+        # --user is a channel-only lookup; reject when reply_target isn't an
+        # RFC 2811 channel name (i.e. invocation came via msg-bind).
+        if target_user and not reply_target.startswith(("#", "&")):
+            putserv(
+                f"PRIVMSG {reply_target} :--user only works in a channel."
+                f" Try .wz --user {target_user} in #channel."
+            )
+            return
 
         try:
             metar, units, query, units_explicit = parse_flags(text)
         except ParseFlagsError as e:
-            putserv(f"PRIVMSG {channel} :{nick}: {e}")
+            putserv(f"PRIVMSG {reply_target} :{prefix}{e}")
             return
 
         if target_user and query:
             putserv(
-                f"PRIVMSG {channel} :{nick}: --user cannot be combined with a location query."
+                f"PRIVMSG {reply_target} :{prefix}--user cannot be combined with a location query."
                 f" Try .wz --user {target_user}"
             )
             return
 
-        _do_fetch_weather(nick, handle, metar, units, query, units_explicit, channel, target_user)
+        _do_fetch_weather(
+            handle, metar, units, query, units_explicit, reply_target, prefix, target_user
+        )
 
     except Exception:
         putlog(f"weather: unhandled exception in handle_wz:\n{traceback.format_exc()}")
-        putserv(f"PRIVMSG {channel} :{nick}: An unexpected error occurred. Please try again later.")
+        putserv(
+            f"PRIVMSG {reply_target} :{prefix}An unexpected error occurred. Please try again later."
+        )
 
 
-def handle_wzset(nick: str, host: str, handle: str, channel: str, text: str) -> None:
+def handle_wz(nick: str, host: str, handle: str, channel: str, text: str) -> None:
+    _handle_wz_impl(handle, text, reply_target=channel, prefix=f"{nick}: ")
+
+
+def handle_wz_msg(nick: str, host: str, handle: str, text: str) -> None:
+    _handle_wz_impl(handle, text, reply_target=nick, prefix="")
+
+
+def _handle_wzset_impl(
+    handle: str,
+    text: str,
+    reply_target: str,
+    prefix: str,
+) -> None:
     try:
         if handle == "*":
             putserv(
-                f"PRIVMSG {channel} :{nick}: You must be a registered bot user"
+                f"PRIVMSG {reply_target} :{prefix}You must be a registered bot user"
                 f" to save preferences. Try .wzhelp for usage."
             )
             return
 
         if not text.strip():
             putserv(
-                f"PRIVMSG {channel} :{nick}: Usage:"
+                f"PRIVMSG {reply_target} :{prefix}Usage:"
                 f" .wzset [--metar] [--metric|--imperial] <location>"
             )
             return
@@ -242,13 +275,13 @@ def handle_wzset(nick: str, host: str, handle: str, channel: str, text: str) -> 
         try:
             metar, units, location, units_explicit = parse_flags(text)
         except ParseFlagsError as e:
-            putserv(f"PRIVMSG {channel} :{nick}: {e}")
+            putserv(f"PRIVMSG {reply_target} :{prefix}{e}")
             return
 
         if not location:
             if metar:
                 putserv(
-                    f"PRIVMSG {channel} :{nick}: --metar requires an ICAO code (e.g. KSFO). "
+                    f"PRIVMSG {reply_target} :{prefix}--metar requires an ICAO code (e.g. KSFO). "
                     f"Use .wzset --metar <ICAO> to save a METAR default."
                 )
                 return
@@ -257,7 +290,7 @@ def handle_wzset(nick: str, host: str, handle: str, channel: str, text: str) -> 
             pref.units = units
             prefs.set_pref(handle, pref)
             putserv(
-                f"PRIVMSG {channel} :{nick}: Preference updated."
+                f"PRIVMSG {reply_target} :{prefix}Preference updated."
                 f" Default is now {_pref_to_str(pref)}"
             )
             return
@@ -265,13 +298,15 @@ def handle_wzset(nick: str, host: str, handle: str, channel: str, text: str) -> 
         try:
             loc = resolver.classify(location)
         except ResolverError:
-            putserv(f"PRIVMSG {channel} :{nick}: Unknown location format. Try .wzhelp for usage.")
+            putserv(
+                f"PRIVMSG {reply_target} :{prefix}Unknown location format. Try .wzhelp for usage."
+            )
             return
 
         if metar and loc.type != LocationType.ICAO:
             putserv(
-                f"PRIVMSG {channel} :{nick}: --metar is only valid with ICAO codes (e.g. KSFO). "
-                f"Location not saved."
+                f"PRIVMSG {reply_target} :{prefix}--metar is only valid with ICAO codes"
+                f" (e.g. KSFO). Location not saved."
             )
             return
 
@@ -280,7 +315,7 @@ def handle_wzset(nick: str, host: str, handle: str, channel: str, text: str) -> 
             provider = _router.route(loc, metar=metar)
         except ProviderError as e:
             putserv(
-                f"PRIVMSG {channel} :{nick}: {e}"
+                f"PRIVMSG {reply_target} :{prefix}{e}"
                 f" Location not saved — check the location and try .wzset again."
             )
             return
@@ -289,7 +324,7 @@ def handle_wzset(nick: str, host: str, handle: str, channel: str, text: str) -> 
             provider.get_weather(loc)
         except ProviderError as e:
             putserv(
-                f"PRIVMSG {channel} :{nick}: {e}"
+                f"PRIVMSG {reply_target} :{prefix}{e}"
                 f" Location not saved — check the location and try .wzset again."
             )
             return
@@ -299,11 +334,21 @@ def handle_wzset(nick: str, host: str, handle: str, channel: str, text: str) -> 
         pref.metar = metar
         pref.units = units
         prefs.set_pref(handle, pref)
-        putserv(f"PRIVMSG {channel} :{nick}: Default set to {_pref_to_str(pref)}")
+        putserv(f"PRIVMSG {reply_target} :{prefix}Default set to {_pref_to_str(pref)}")
 
     except Exception:
         putlog(f"weather: unhandled exception in handle_wzset:\n{traceback.format_exc()}")
-        putserv(f"PRIVMSG {channel} :{nick}: An unexpected error occurred. Please try again later.")
+        putserv(
+            f"PRIVMSG {reply_target} :{prefix}An unexpected error occurred. Please try again later."
+        )
+
+
+def handle_wzset(nick: str, host: str, handle: str, channel: str, text: str) -> None:
+    _handle_wzset_impl(handle, text, reply_target=channel, prefix=f"{nick}: ")
+
+
+def handle_wzset_msg(nick: str, host: str, handle: str, text: str) -> None:
+    _handle_wzset_impl(handle, text, reply_target=nick, prefix="")
 
 
 HELP_LINES = [
@@ -337,6 +382,14 @@ def handle_wzhelp(nick: str, host: str, handle: str, channel: str, text: str | N
         putlog(f"weather: unhandled exception in handle_wzhelp:\n{traceback.format_exc()}")
 
 
+def handle_wzhelp_msg(nick: str, host: str, handle: str, text: str | None = None) -> None:
+    try:
+        for line in HELP_LINES:
+            putserv(f"PRIVMSG {nick} :{line}")
+    except Exception:
+        putlog(f"weather: unhandled exception in handle_wzhelp_msg:\n{traceback.format_exc()}")
+
+
 # Rehash safety: unbind previous iteration's binds before re-registering
 if "WZ_BINDS" in globals():
     for b in WZ_BINDS:
@@ -348,5 +401,8 @@ WZ_BINDS = [
     bind("pub", "*", ".wz", handle_wz),
     bind("pub", "*", ".wzset", handle_wzset),
     bind("pub", "*", ".wzhelp", handle_wzhelp),
-    bind("msg", "*", ".wzhelp", handle_wzhelp),
+    bind("msg", "*", ".w", handle_wz_msg),
+    bind("msg", "*", ".wz", handle_wz_msg),
+    bind("msg", "*", ".wzset", handle_wzset_msg),
+    bind("msg", "*", ".wzhelp", handle_wzhelp_msg),
 ]


### PR DESCRIPTION
## Summary

- All weather commands (`.w`, `.wz`, `.wzset`, `.wzhelp`) are now bound to both pub and msg, so users can query the bot privately instead of having to be in-channel.
- Replies mirror the invocation context: channel in → channel out (with `nick: ...` prefix, unchanged); PM in → PM out, no prefix.
- `--user <nick>` stays channel-only and returns a clear error if used in PM. The channel-vs-PM check derives from RFC 2811 channel-name prefixes (`#`/`&`) on the reply target rather than a sentinel.
- Replaces the old `bind("msg", "*", ".wzhelp", handle_wzhelp)` (which called the 5-arg pub handler with 4 args and produced a malformed `PRIVMSG` for the channel echo) with a dedicated `handle_wzhelp_msg`.

Closes #68.

## Test plan

- [x] Existing handler tests still pass
- [x] New tests cover PM reply routing, no-prefix-in-PM, `--user` PM rejection, `.wzhelp` PM with no channel echo, and per-bind handler-identity registration coverage
- [x] Full python suite green: `uv run --python 3.12 --extra dev pytest tests/ -v` → 175 passed
- [x] `ruff check` + `ruff format --check` clean
- [x] yamllint + ansible-lint clean
- [x] Manual verification on a deployed bot — in channel and via PM, run `.wz 94025`, `.wz`, `.wzset 94025`, `.wzhelp`, `.wz --user someone`