### PR TITLE
fix: use a healthcheck that doesn't create noise

### DIFF
--- a/bots/Decisis/docker-compose.yml
+++ b/bots/Decisis/docker-compose.yml
@@ -46,7 +46,7 @@ services:
       - no-new-privileges:true
 
     healthcheck:
-      test: ["CMD", "nc", "-z", "127.0.0.1", "2020"]
+      test: ["CMD-SHELL", "test -f /eggdrop/data/pid.Decisis && test -d /proc/$(cat /eggdrop/data/pid.Decisis)"]
       interval: 30s
       timeout: 5s
       retries: 3

--- a/bots/Pompone/docker-compose.yml
+++ b/bots/Pompone/docker-compose.yml
@@ -56,7 +56,7 @@ services:
       - no-new-privileges:true
 
     healthcheck:
-      test: ["CMD", "nc", "-z", "127.0.0.1", "2020"]
+      test: ["CMD-SHELL", "test -f /eggdrop/data/pid.Pompone && test -d /proc/$(cat /eggdrop/data/pid.Pompone)"]
       interval: 30s
       timeout: 5s
       retries: 3

--- a/bots/Xerokewl/docker-compose.yml
+++ b/bots/Xerokewl/docker-compose.yml
@@ -51,7 +51,7 @@ services:
       - no-new-privileges:true
 
     healthcheck:
-      test: ["CMD", "nc", "-z", "127.0.0.1", "1855"]
+      test: ["CMD-SHELL", "test -f /eggdrop/data/pid.Xerokewl && test -d /proc/$(cat /eggdrop/data/pid.Xerokewl)"]
       interval: 30s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
the previous healthcheck used netcat to check the dcc port, but that would trigger log noise due to eggdrop's internal threaded dns module trying to do a reverse lookup of the connecting ip.  netcat would sever the connection and the dns module would race to return the PTR for the connecting ip.  moves to checking the process directly and lets external monitoring handle the dcc port check.