### PR TITLE
docs: wire weather + bseen help output to efnetmoto.com

### DIFF
--- a/shared/python-scripts/weather.py
+++ b/shared/python-scripts/weather.py
@@ -126,6 +126,7 @@ def _do_fetch_weather(
         if not registered:
             putserv(
                 f"PRIVMSG {reply_target} :{prefix}{target_user} is not registered with the bot."
+                f" See https://efnetmoto.com/docs/user/weather/#getting-registered"
             )
             return
         pref = prefs.get_pref(target_user)
@@ -140,7 +141,9 @@ def _do_fetch_weather(
         if handle == "*":
             putserv(
                 f"PRIVMSG {reply_target} :{prefix}You must be registered with the bot"
-                f" to use a saved default. Try .wz <location>."
+                f" to use a saved default. Ask an op to add you:"
+                f" https://efnetmoto.com/docs/user/weather/#getting-registered"
+                f"  (for now, .wz <location> works without an account)"
             )
             return
         pref = prefs.get_pref(handle)
@@ -261,7 +264,9 @@ def _handle_wzset_impl(
         if handle == "*":
             putserv(
                 f"PRIVMSG {reply_target} :{prefix}You must be a registered bot user"
-                f" to save preferences. Try .wzhelp for usage."
+                f" to save preferences. Ask an op to add you:"
+                f" https://efnetmoto.com/docs/user/weather/#getting-registered"
+                f"  (see .wzhelp for command usage)"
             )
             return
 
@@ -370,6 +375,7 @@ HELP_LINES = [
     "  .w/.wz <32-char station slug>              — query by station slug",
     "  .w/.wz <CALLSIGN with SSID 13>             - query by CWOP Callsign"
     "  .wzset <URL or slug>                       — save as your default",
+    "Full docs: https://efnetmoto.com/docs/user/weather/",
 ]
 
 

--- a/shared/tcl-scripts/bseen1.4.2.tcl
+++ b/shared/tcl-scripts/bseen1.4.2.tcl
@@ -868,18 +868,21 @@ proc bs_help_msg_seen {nick uhost hand args} {
     puthelp "notice $nick :   Queries can be in the following formats:"
     puthelp "notice $nick :     'regular':  seen lamer; seen lamest "
     puthelp "notice $nick :     'masked':   seen *l?mer*; seen *.lame.com; seen *.edu #mychan"
+    puthelp "notice $nick :  Full docs: https://efnetmoto.com/docs/user/bseen/"
     return 0
 }
 proc bs_help_msg_chanstats {nick uhost hand args} {
     global bs; if {[bs_flood $nick $uhost]} {return 0}
     puthelp "notice $nick :###  chanstats <chan>          $bs(version)"
     puthelp "notice $nick :   Returns the usage statistics of #chan in the seen database."
+    puthelp "notice $nick :  Full docs: https://efnetmoto.com/docs/user/bseen/"
     return 0
 }
 proc bs_help_msg_seenstats {nick uhost hand args} {
     global bs; if {[bs_flood $nick $uhost]} {return 0}
     puthelp "notice $nick :###  seenstats          $bs(version)"
     puthelp "notice $nick :   Returns the status of the bseen database."
+    puthelp "notice $nick :  Full docs: https://efnetmoto.com/docs/user/bseen/"
     return 0
 }
 bind dcc -|- seenversion bs_version

--- a/shared/tcl-scripts/quoteengine.tcl
+++ b/shared/tcl-scripts/quoteengine.tcl
@@ -336,7 +336,8 @@ proc quote_help {nick host handle channel text} {
     putserv "PRIVMSG $nick :Commands for the QuoteEngine script: <req'd> \[optional\]"
     putserv "PRIVMSG $nick :  !addquote <title> <quote text> -\
         adds a quote to the database. Friends (+f) only."
-    putserv "PRIVMSG $nick :  !delquote <title> - deletes a quote. Ops (+o) only."
+    putserv "PRIVMSG $nick :  !delquote <title> - deletes a quote. Ops (+o):"
+    putserv "PRIVMSG $nick :    your own; botmasters (+m) any."
     putserv "PRIVMSG $nick :  !randquote \[search text\] - fetches a random quote"
     putserv "PRIVMSG $nick :  !randauthor \[nick\] - fetches a random quote added by <nick>"
     putserv "PRIVMSG $nick :  !quote <title> - fetches the quote with <title>"

--- a/shared/tcl-scripts/quoteengine.tcl
+++ b/shared/tcl-scripts/quoteengine.tcl
@@ -335,17 +335,19 @@ proc quote_help {nick host handle channel text} {
         as our options have recently changed."
     putserv "PRIVMSG $nick :Commands for the QuoteEngine script: <req'd> \[optional\]"
     putserv "PRIVMSG $nick :  !addquote <title> <quote text> -\
-        adds a quote to the database. Ops only."
-    putserv "PRIVMSG $nick :  !delquote <title> - deletes a quote. Ops only."
+        adds a quote to the database. Friends (+f) only."
+    putserv "PRIVMSG $nick :  !delquote <title> - deletes a quote. Ops (+o) only."
     putserv "PRIVMSG $nick :  !randquote \[search text\] - fetches a random quote"
+    putserv "PRIVMSG $nick :  !randauthor \[nick\] - fetches a random quote added by <nick>"
     putserv "PRIVMSG $nick :  !quote <title> - fetches the quote with <title>"
-    putserv "PRIVMSG $nick :  !quoteinfo <title> - gets info about a quote"
+    putserv "PRIVMSG $nick :  !quoteinfo <title> - who added a quote and when"
     putserv "PRIVMSG $nick :  !titlesearch <text> - finds all quote titles containing 'text'"
     putserv "PRIVMSG $nick :  !quotesearch <text> - finds all quotes containing 'text'"
-    putserv "PRIVMSG $nick :  !quotestats - get quote entry information"
+    putserv "PRIVMSG $nick :  !quotestats - total quotes, and how many you've added"
     putserv "PRIVMSG $nick :  !quotever - get the version of the script"
-    putserv "PRIVMSG $nick :  Some commands have synonyms and\
-        spoonerisms: !getquote !deletequote !searchtitle"
+    putserv "PRIVMSG $nick :  !quote and !getquote also work via /msg XeroKewl"
+    putserv "PRIVMSG $nick :  Synonyms: !getquote !quoteadd !deletequote\
+        !searchtitle !searchtitles !searchquotes !searchquote"
     putserv "PRIVMSG $nick :  Full docs: https://efnetmoto.com/docs/user/quotes/"
     putserv "PRIVMSG $nick :  (End of help)"
     return 0

--- a/shared/tcl-scripts/quoteengine.tcl
+++ b/shared/tcl-scripts/quoteengine.tcl
@@ -346,6 +346,7 @@ proc quote_help {nick host handle channel text} {
     putserv "PRIVMSG $nick :  !quotever - get the version of the script"
     putserv "PRIVMSG $nick :  Some commands have synonyms and\
         spoonerisms: !getquote !deletequote !searchtitle"
+    putserv "PRIVMSG $nick :  Full docs: https://efnetmoto.com/docs/user/quotes/"
     putserv "PRIVMSG $nick :  (End of help)"
     return 0
 }


### PR DESCRIPTION
Points the bot help text at the new docs site (**efnetmoto.com**) so members get a link to real docs where the in-bot message is too terse.

Closes #63 — the "not registered" messages now name the action ("Ask an op to add you") and link to `#getting-registered`, addressing the issue's request that the messaging "reflect what registration means, how to get registered and who can help."

## weather.py (XeroKewl)

- **`HELP_LINES`** — appends `Full docs: https://efnetmoto.com/docs/user/weather/` (shown by `.wzhelp`).
- **The three "not registered" messages** (bare `.w`/`.wz`, `.wzset`, `--user <nick>`) now name the action (**"Ask an op to add you"**) and link the `#getting-registered` anchor, instead of the bare `.wz <location>` / `.wzhelp` nudges that never told anyone *how* to actually get registered. The bare `.w`/`.wz` message keeps the immediate workaround (`.wz <location> works without an account`).

This is the "most-confusing path" fix from the modernization plan: an unregistered user doing a bare `.w` gets told how to get registered, not just "try `.wz <location>`."

## bseen1.4.2.tcl (Decisis)

- The three `/msg` help procs (`help seen` / `help chanstats` / `help seenstats`) append a `Full docs: https://efnetmoto.com/docs/user/bseen/` line.

## quoteengine.tcl (XeroKewl)

Two changes:

1. `quote_help` (shown by `!quotehelp`) appends `Full docs: https://efnetmoto.com/docs/user/quotes/`. A new quotes doc page was added to the site for this (`/docs/user/quotes/`), covering `!quote`/`!getquote` (also via `/msg`), `!addquote` (needs `+f`), `!randquote`/`!randauthor`, `!titlesearch`/`!quotesearch`, `!delquote` (ops `+o`), and stats/info/version.
2. **Fixed the `quote_help` output to match the actual binds** — it had drifted:
   - `!addquote` said "Ops only" but the bind is `+f` (friend) → now "Friends (+f) only."
   - `!quotestats` said "get quote entry information" (that's `!quoteinfo`'s job) → now "total quotes, and how many you've added"; `!quoteinfo` → "who added a quote and when."
   - `!randauthor` was missing entirely → added.
   - `!quote`/`!getquote` also work via `/msg XeroKewl` → noted.
   - Synonyms line was incomplete → added `!quoteadd`, `!searchtitles`, `!searchquotes`, `!searchquote`.

## NOT wired

- **`searchbot.py` / `!g`** (Pompone) — search help-output wiring was declined (interface too simple). Pompone is untouched.

## Deploy

Wiring takes effect after redeploying via the fleet Ansible playbooks: **Xerokewl** (weather + quote, one redeploy) and **Decisis** (bseen). Pompone is not redeployed.

Site is live at `https://efnetmoto.com/` (apex canonical); the linked doc pages resolve.
