### PR TITLE
docs: trim IRC help strings now that long-form docs exist

### DIFF
--- a/shared/python-scripts/searchbot.py
+++ b/shared/python-scripts/searchbot.py
@@ -110,7 +110,10 @@ def _handle_search_impl(nick: str, text: str, reply_target: str, prefix: str) ->
     try:
         query = text.strip()
         if not query:
-            putserv(f"PRIVMSG {reply_target} :{prefix}Usage: {_SEARCH_TRIGGER} <search query>")
+            putserv(
+                f"PRIVMSG {reply_target} :{prefix}Usage: {_SEARCH_TRIGGER} <search query>"
+                f"  (docs: https://efnetmoto.com/docs/user/search/)"
+            )
             return
         if len(query) > _MAX_QUERY_LENGTH:
             putserv(

--- a/shared/python-scripts/tests/searchbot/test_searchbot_handlers.py
+++ b/shared/python-scripts/tests/searchbot/test_searchbot_handlers.py
@@ -74,7 +74,9 @@ def _sent_messages(putserv_mock):
 def test_empty_query_replies_usage(putserv_mock):
     sb.handle_search("alice", "h", "hand", "#test", "")
     putserv_mock.assert_called_once()
-    assert putserv_mock.call_args[0][0] == "PRIVMSG #test :alice: Usage: !g <search query>"
+    msg = putserv_mock.call_args[0][0]
+    assert msg.startswith("PRIVMSG #test :alice: Usage: !g <search query>")
+    assert "https://efnetmoto.com/docs/user/search/" in msg
 
 
 def test_whitespace_only_query_replies_usage(putserv_mock):

--- a/shared/python-scripts/tests/weather/test_weather_handlers.py
+++ b/shared/python-scripts/tests/weather/test_weather_handlers.py
@@ -66,7 +66,7 @@ def test_wzset_unregistered_user_blocked(putserv_mock):
     putserv_mock.assert_called_once()
     msg = putserv_mock.call_args[0][0]
     assert "registered bot user" in msg
-    assert ".wzhelp" in msg
+    assert "docs/user/weather/#getting-registered" in msg
 
 
 def test_wzset_flags_only_unregistered_user_blocked(putserv_mock):
@@ -85,7 +85,7 @@ def test_wz_no_args_unregistered_user_blocked(putserv_mock):
     putserv_mock.assert_called_once()
     msg = putserv_mock.call_args[0][0]
     assert "registered with the bot" in msg
-    assert ".wz <location>" in msg
+    assert "docs/user/weather/#getting-registered" in msg
 
 
 def test_wz_with_location_unregistered_user_allowed(putserv_mock):

--- a/shared/python-scripts/weather.py
+++ b/shared/python-scripts/weather.py
@@ -143,7 +143,6 @@ def _do_fetch_weather(
                 f"PRIVMSG {reply_target} :{prefix}You must be registered with the bot"
                 f" to use a saved default. Ask an op to add you:"
                 f" https://efnetmoto.com/docs/user/weather/#getting-registered"
-                f"  (for now, .wz <location> works without an account)"
             )
             return
         pref = prefs.get_pref(handle)
@@ -266,7 +265,6 @@ def _handle_wzset_impl(
                 f"PRIVMSG {reply_target} :{prefix}You must be a registered bot user"
                 f" to save preferences. Ask an op to add you:"
                 f" https://efnetmoto.com/docs/user/weather/#getting-registered"
-                f"  (see .wzhelp for command usage)"
             )
             return
 
@@ -363,18 +361,8 @@ HELP_LINES = [
     "  .w/.wz --user <nick>                                — use another user's saved default",
     "  .wzset [--metar] [--metric|--imperial] <location>  — save a default location",
     "  .wzset --metric|--imperial                         — update saved units only",
-    "  .wzhelp                                             — this message",
-    "Location formats: ZIP (94025), City/State (San Mateo, CA), IATA (SFO)",
-    "--metar    : raw aviation weather; requires an ICAO code (e.g. .wz --metar KSFO)",
-    "Note: ICAO codes (KSFO) only work with --metar. For general weather use IATA (SFO).",
-    "--metric   : show metric first, imperial second (default)",
-    "--imperial : show imperial first, metric second",
-    "Use --metric or --imperial with .wzset to change your saved default",
-    "Personal weather stations (Ambient Weather Network):",
-    "  .w/.wz <ambientweather.net/dashboard/URL>  — query by dashboard URL",
-    "  .w/.wz <32-char station slug>              — query by station slug",
-    "  .w/.wz <CALLSIGN with SSID 13>             - query by CWOP Callsign"
-    "  .wzset <URL or slug>                       — save as your default",
+    "Location formats: ZIP, City/State, IATA (SFO); ICAO (KSFO) only with --metar;",
+    "  PWS: ambientweather.net URL, 32-char slug, or CWOP CALLSIGN-13.",
     "Full docs: https://efnetmoto.com/docs/user/weather/",
 ]
 

--- a/shared/tcl-scripts/quoteengine.tcl
+++ b/shared/tcl-scripts/quoteengine.tcl
@@ -348,9 +348,6 @@ proc quote_help {nick host handle channel text} {
     putserv "PRIVMSG $nick :  !quotesearch <text> - finds all quotes containing 'text'"
     putserv "PRIVMSG $nick :  !quotestats - total quotes, and how many you've added"
     putserv "PRIVMSG $nick :  !quotever - get the version of the script"
-    putserv "PRIVMSG $nick :  quote and getquote via /msg XeroKewl (!quote/!getquote also work)"
-    putserv "PRIVMSG $nick :  Synonyms: !getquote !quoteadd !deletequote\
-        !searchtitle !searchtitles !searchquotes !searchquote"
     putserv "PRIVMSG $nick :  Full docs: https://efnetmoto.com/docs/user/quotes/"
     putserv "PRIVMSG $nick :  (End of help)"
     return 0


### PR DESCRIPTION
## Why

The user-facing docs on `efnetmoto.github.io` (`docs/user/weather.md`, `search.md`, `quotes.md`) now carry the long-form command reference that the in-IRC help strings duplicated. This PR trims the IRC surface to a short command list plus a single docs link, and lets the doc pages own the prose, flag tables, and aliases.

Guiding principle applied:

> In-channel help → short command list + single docs link.
> Error messages → error + one docs deep-link.
> Drop procedural prose the docs page now owns.

## Changes

**`weather.py`** — `.wzhelp`
- `HELP_LINES` 18 → 9 lines: command list + one-line location-format summary + docs link. Dropped the per-flag paragraphs, the ICAO/IATA note, and the 4-line PWS block (all now in `docs/user/weather`).
- **Bug fix:** a missing trailing comma on the CWOP line was implicitly concatenating it with the following `.wzset` line into one over-long merged line — the `.wzset <URL or slug>` PWS hint was silently missing from help output. The collapse fixes this (verified via AST parse before/after).
- Dropped the redundant inline hints from the two unregistered-user errors:
  - `(for now, .wz <location> works without an account)`
  - `(see .wzhelp for command usage)`
  
  Each already carries a deep-link to `docs/user/weather/#getting-registered`.

**`searchbot.py`** — `Usage: !g <query>`
- Appended `(docs: https://efnetmoto.com/docs/user/search/)`. Search had no docs link at all before, and `docs/user/search` now exists.

**`quoteengine.tcl`** — `!quotehelp`
- Dropped the `quote and getquote via /msg …` and `Synonyms: …` lines (both covered by the doc's alias column); kept the docs link. 17 → 15 IRC lines.

**Tests**
- Three assertions that encoded the dropped inline hints updated to assert the docs deep-link instead.
- The `.wzhelp` count-based tests use `len(HELP_LINES)` and adapt automatically to the shorter list.

## Verification

- `ruff check .` — pass
- `ruff format --check .` — pass (45 files already formatted)
- `pytest tests/` — **276 passed**
- All new lines ≤ 100 cols (ruff line-length 100; tclint 100).