### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
             submodules: true
             fetch-depth: 0
 
       - name: Run yamllint
-        uses: ansible-actions/yamllint-action@main
+        uses: ansible-actions/yamllint-action@e4e6dfffffc1e419e4f414bb05c57e540413198c # pin: main @ 2026-07-25
         with:
           target: "."
 
@@ -26,13 +26,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Force install Ansible Galaxy collections
         run: ansible-galaxy collection install -r ansible/requirements.yml --force
 
       - name: Run ansible-lint
-        uses: ansible/ansible-lint@main
+        uses: ansible/ansible-lint@43b00b540e6cdfd773e3b74e0f8afebb49967847 # pin: main @ 2026-07-25
         with:
           requirements_file: ansible/requirements.yml
 
@@ -41,10 +41,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.11'
 
@@ -66,10 +66,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@master
+        uses: ludeeus/action-shellcheck@00b27aa7cb85167568cb48a3838b75f4265f2bca # pin: master @ 2026-07-25
         with:
           scandir: '.'
           severity: warning
@@ -79,10 +79,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Run hadolint
-        uses: hadolint/hadolint-action@v3.1.0
+        uses: hadolint/hadolint-action@54c9adbab1582c2ef04b2016b760714a4bfde3cf # v3.1.0
         with:
           dockerfile: services/*/Dockerfile
           recursive: true
@@ -92,10 +92,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Run markdownlint
-        uses: articulate/actions-markdownlint@v1
+        uses: articulate/actions-markdownlint@17b8abe7407cd17590c006ecc837c35e1ac3ed83 # v1.1.0
         with:
           config: .markdownlint.yml
           files: '**/*.md'
@@ -106,7 +106,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Install dependencies
         run: |
@@ -124,12 +124,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
 
       - name: Run Gitleaks
-        uses: gitleaks/gitleaks-action@v2
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '1.25'
           cache-dependency-path: services/url-shortener/go.sum

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # v3.2.4
 
       - name: Lint (ruff check)
         run: |


### PR DESCRIPTION
Pins every `uses:` across `ci.yml`, `go-tests.yml`, and `python-tests.yml` to an immutable commit SHA instead of a moving tag or branch. Behavior is unchanged — each SHA is the exact commit the previous ref pointed to at pin time (verified against the corresponding release tag). A trailing comment records the version (or the branch it was pinned from) so future bumps and Dependabot updates stay readable.

### Highest-impact change: three actions were on moving BRANCH refs
Branch refs are the biggest supply-chain risk here — the tip can shift on *any* upstream commit, intentionally or via compromise. These are now frozen to the branch-tip SHA at pin time:

| Action | Was | Pinned to |
|---|---|---|
| ansible-actions/yamllint-action | `@main` | `…13198c` # pin: main |
| ansible/ansible-lint | `@main` | `…967847` # pin: main |
| ludeeus/action-shellcheck | `@master` | `…65f2bca` # pin: master |

(These are branch-tip pins, not release tags — preserves the exact versions currently in use. They can be switched to the latest release-tag SHA later if you want stable, reviewed releases instead of branch tips.)

### Tag-based pins
| Action | Was | Now (version) |
|---|---|---|
| actions/checkout | `@v4` | `…677262` # v4.4.0 |
| actions/setup-python | `@v5` | `…d87065` # v5.6.0 |
| hadolint/hadolint-action | `@v3.1.0` | `…de3cf` # v3.1.0 |
| articulate/actions-markdownlint | `@v1` | `…3ed83` # v1.1.0 |
| gitleaks/gitleaks-action | `@v2` | `…29070c7` # v2.3.9 |
| actions/setup-go | `@v5` | `…1baff` # v5.6.0 |
| astral-sh/setup-uv | `@v3` | `…55d39` # v3.2.4 |

**Why:** moving refs can be re-pointed; SHAs are immutable. This is the lowest-effort hardening of the CI supply chain, and it matters most for this repo since CI runs Ansible deploy logic.

**Follow-up (not in this PR):** add a Dependabot config (`github-actions` ecosystem) so these SHAs get bumped automatically — otherwise they go stale. Happy to open that as a separate PR.