### PR TITLE
ci: add Dependabot config for github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+# Dependabot keeps the pinned GitHub Actions commit SHAs (see
+# .github/workflows/*.yml) up to date. Each week it bumps each SHA to the latest
+# release of the action and updates the trailing version comment (e.g. `# v4.4.0`).
+#
+# Updates are grouped into a single weekly PR to keep noise low; every PR still
+# goes through branch protection (1 required review on main), so a human reviews
+# each bump before it lands.
+#
+# Note: SHA pins that carry a non-version comment (e.g. `# pin: main @ <date>`)
+# are intentionally frozen — Dependabot will not bump them. Bump those manually
+# when you deliberately want to move to a newer branch tip.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "dependencies"
+      - "github-actions"


### PR DESCRIPTION
Adds `.github/dependabot.yml` to auto-maintain the pinned action SHAs introduced in #75, so they don't go stale.

## What it does
- **Ecosystem:** `github-actions` — scans every `uses:` across `ci.yml`, `go-tests.yml`, `python-tests.yml`.
- **Schedule:** weekly, every **Monday**.
- **Grouping:** all action updates in a single PR per run (one PR/week, not one per action) to keep noise low.
- **Commit prefix:** `ci` → Dependabot commits read `ci: bump actions/checkout from v4.4.0 to v4.5.0`, matching the repo's existing `ci:` convention.
- **Labels:** `dependencies`, `github-actions` (auto-created if absent).

## How updates interact with the SHA pins from #75
- **Release-tagged pins** (e.g. `@<sha> # v4.4.0`): Dependabot **does** maintain these — bumps the SHA to the latest release and rewrites the version comment. Covers 7 actions here: `actions/checkout`, `actions/setup-python`, `hadolint/hadolint-action`, `articulate/actions-markdownlint`, `gitleaks/gitleaks-action`, `actions/setup-go`, `astral-sh/setup-uv`.
- **Branch-tip pins** (`@<sha> # pin: main @ <date>` — `ansible-actions/yamllint-action`, `ansible/ansible-lint`, `ludeeus/action-shellcheck`): Dependabot **does not** bump these (no version comment to track). They stay frozen at the pinned SHA — which is the intent: a deliberate, reviewed move when you choose to advance them, not an automatic one. To make any of them Dependabot-maintained, re-pin to a release tag with a `# vX.Y.Z` comment (ansible-lint has `v26.6.0`, action-shellcheck has `2.0.0`; yamllint-action's only release is `v0.0.2`, likely behind the branch tip).

## Human gate preserved
Every Dependabot PR still goes through branch protection — **1 required review on `main`** — so a human reviews each bump (including any major-version bump) before it lands. `enforce_admins` is off, so an owner can also bypass and merge directly.
