### PR TITLE
ci: skip gitleaks job on Dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,7 @@ jobs:
 
   secrets-scan:
     name: Secrets Scan
+    if: github.actor != 'dependabot[bot]'  # Actions secrets (incl. GITLEAKS_LICENSE) are withheld on Dependabot PRs
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
Adds `if: github.actor != 'dependabot[bot]'` to the `secrets-scan` job in `ci.yml`. On Dependabot PRs the job reports **skipped** instead of **failed**; on member PRs and pushes it runs exactly as today.

## The problem this fixes
The Dependabot PR `ci: bump the github-actions group with 6 updates` (run [30170505643](https://github.com/efnetmoto/efnetmoto-fleet/actions/runs/30170505643)) failed **only** the `Secrets Scan` job; the other 7 checks passed. The gitleaks step's env block in that run showed:

```
env:
  GITHUB_TOKEN: ***            ← injected
  GITLEAKS_LICENSE:            ← EMPTY
[efnetmoto] is an organization. License key is required.
##[error]🛑 missing gitleaks license.
```

Same workflow on a member PR (`chore/pin-actions-sha`) had `GITLEAKS_LICENSE: ***` and scanned fine.

## Why the license is missing there (this is NOT a propagation bug)
GitHub **withholds all Actions secrets — org-level *and* repo-level — from `pull_request` runs opened by Dependabot** (and from forks). Only the read-only `GITHUB_TOKEN` is injected. This is a deliberate security boundary so a compromised dependency that tricks Dependabot into opening a PR cannot exfiltrate secrets through the workflow. The org `GITLEAKS_LICENSE` propagates fine to every member PR and every push — it is structurally unavailable to Dependabot-triggered runs only.

gitleaks-action requires the license for org repos, so on those runs it hard-errors. Since `Secrets Scan` is one of the **8 required status checks** on `main`, every Dependabot PR is currently blocked from merging — which defeats the Dependabot config merged in #76.

## Why skipping is safe (no detection loss)
- Dependabot PRs only ever touch `.github/workflows/*.yml` and `dependabot.yml` (action version refs). Those files cannot introduce a secret — gitleaks on them is advisory-only anyway.
- The real secret gate is **GitHub-native secret scanning + push protection**, already enabled on this repo. That runs **server-side on every push and every PR — including Dependabot PRs — independent of Actions secrets**, and push protection blocks a plaintext secret before it ever lands in a commit. Removing gitleaks from the *required* set does not open a hole; native scanning is the actual gate, gitleaks stays a complementary layer that still runs (and passes) on member PRs where it can reach the license.

## 🔴 REQUIRED follow-up (UI step — not in this PR)
A skipped job cannot satisfy a required-check rule. **After merging this PR**, remove `Secrets Scan` from the required status checks on `main`:

`https://github.com/efnetmoto/efnetmoto-fleet/settings/branches` → edit the `main` rule → "Require status checks" → **uncheck `Secrets Scan`** → Save. Keep the other 7 required.

Until you do this, Dependabot PRs stay blocked (the job will be `skipped`, which still does not satisfy a required check). The other 7 checks stay required, so Dependabot PRs remain gated by all the linters + ansible syntax.

## What I did not consider
`pull_request_target` (the classic "make secrets available on PRs" escape hatch) checks out untrusted PR code with base-branch permissions and is a well-known footgun — not worth it to keep one advisory check green.
